### PR TITLE
Feature/misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Xcode と Swift のバージョンによっては、 Carthage と CocoaPods で�
    $ pod install
    ```
 
-2. ``SoraQuickStart.xcodeproj`` を Xcode で開いてビルドします。
+2. ``SoraQuickStart.xcworkspace`` を Xcode で開いてビルドします。

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -132,6 +132,9 @@ class ViewController: UIViewController {
             let _ = Sora.shared.setAudioMode(.voiceChat(output: .speaker))
         })
         alert.addAction(.init(title: "キャンセル", style: .cancel, handler: nil))
+        alert.popoverPresentationController?.sourceView = self.view
+        let screenSize = UIScreen.main.bounds
+        alert.popoverPresentationController?.sourceRect = CGRect(x: screenSize.size.width/2, y: screenSize.size.height, width: 0, height: 0)
         present(alert, animated: true)
     }
     


### PR DESCRIPTION
## 変更内容

- README.md のビルド手順を修正
- 音声出力選択ボタンをタップした際に iPad がクラッシュする問題を修正

## 音声出力選択ボタンをタップした際に iPad で発生していたエラー

```
Exception	NSException *	"Your application has presented a UIAlertController (<UIAlertController: 0x127071400>) of style UIAlertControllerStyleActionSheet from UINavigationController (<UINavigationController: 0x123021600>). The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation."	0x0000000283def2d0
name	__NSCFConstantString *	"NSGenericException"	0x00000002063895a0
reason	__NSCFString *	"Your application has presented a UIAlertController (<UIAlertController: 0x127071400>) of style UIAlertControllerStyleActionSheet from UINavigationController (<UINavigationController: 0x123021600>). The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation."	0x0000000123914570
userInfo	void *	NULL	0x0000000000000000
reserved	__NSDictionaryM *	2 key/value pairs	0x00000002833551a0
```

参照: https://re-engines.com/2017/11/01/swiftipad%E3%81%AEactionsheet%E8%A1%A8%E7%A4%BA%E3%81%A7%E3%82%AF%E3%83%A9%E3%83%83%E3%82%B7%E3%83%A5%E3%81%99%E3%82%8B%E5%95%8F%E9%A1%8C/