### PR TITLE
受信 => 送信 の順番で接続すると、受信側の映像が表示されない問題を修正する

### DIFF
--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -154,6 +154,12 @@ class ViewController: UIViewController {
                                    channelId: soraChannelId,
                                    role: role,
                                    multistreamEnabled: multiplicityControl.selectedSegmentIndex == 1)
+
+        if role == .recvonly {
+            config.peerChannelHandlers.onAddStream = { mediaStream -> Void in
+                mediaStream.videoRenderer = videoView
+            }
+        }
         
         // 接続します。
         // connect() の戻り値 ConnectionTask はここでは使いませんが、

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -67,6 +67,7 @@ class ViewController: UIViewController {
                        multiplicityControl: receiverMultiplicityControl,
                        connectButton: receiverConnectButton)
             receiverMediaChannel = nil
+            receiverVideoView.clear()
         } else {
             connect(role: .recvonly,
                     multiplicityControl: receiverMultiplicityControl,


### PR DESCRIPTION
## 変更内容

- 修正前は、 `受信 => 送信` の順で Sora に接続すると、受信側の映像が表示されませんでした
  - 修正後、以下のパターンで正しく映像が受信できることを確認しました
- 追加で、切断時に受信側のビューをクリアーする処理を追加しました
  - 受信側を自分から切断したケースのみに対応しており、相手側から切断された場合には対応していません

| マルチストリーム | 順番 | 結果 |
|---|---|---|
| あり | 送信 => 受信 | ○ |
| あり | 受信 => 送信 | ○ |
| なし | 送信 => 受信 | ○ |
| なし | 受信 => 送信 | ○ |