### PR TITLE
初回接続時、送信画像が受信側の View に表示される不具合を修正する

### DIFF
--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -73,7 +73,9 @@ class ViewController: UIViewController {
         // ストリームが追加されたら受信用の VideoView をストリームにセットします。
         // このアプリでは、複数のユーザーが接続した場合は最後のユーザーの映像のみ描画します。
         config.mediaChannelHandlers.onAddStream = {stream in
-            stream.videoRenderer = self.receiverVideoView
+            if stream.streamId != config.publisherStreamId {
+                stream.videoRenderer = self.receiverVideoView
+            }
         }
         // 接続先から接続を解除されたときに行う処理です。
         config.mediaChannelHandlers.onDisconnect = { error in


### PR DESCRIPTION
@szktty 
前回の Configration 取得先を変更するコミット(https://github.com/shiguredo/sora-ios-sdk-quickstart/commit/2ec028ba7fdc73f4d7f07979cada11c69452e240) で iOS クイックスタートで初回接続をしたときに受信用 View に送信側の静止画像が表示されるようになってしまいました。

送信側の View には送信映像しか表示したくないため制御を入れたいのですがよい判断方法がないかご相談させてください。
この修正で期待通りの動作をしたのですが、もっとよい（あるべき）方法があれば教えていただきたいです。