### PR TITLE
Podfile から IPHONEOS_DEPLOYMENT_TARGETの指定を削除する

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,21 +10,4 @@ target 'SoraQuickStart' do
   pod 'SwiftLint'
   pod 'SwiftFormat/CLI'
 
-  post_install do |installer|
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '10.0'
-      end
-    end
-  end
-
-# シミュレーターのビルド用の設定です。 arm64 を除いてビルドします。
-# Sora iOS SDK はシミュレーターでのビルドと動作をサポートしませんので、
-# あくまで参考例としてご利用ください。
-#
-# post_install do |installer|
-#   installer.pods_project.build_configurations.each do |config|
-#     config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
-#   end
-
 end


### PR DESCRIPTION
元々以下のコミットで追加された内容ですが、最新の CocoaPods を利用して問題なくビルドができたので元に戻させてください。

https://github.com/shiguredo/sora-ios-sdk-quickstart/commit/deb86f04beef9f1a3a5b0f9bbca177c3611b2d72#diff-8f7d6adf31268a2d897ee34bd170592648d6e520aa237104395e4a4438af50cb

また、arm64 のシミュレータービルドがサポートされるようになったので、arm64 シミュレータービルドを除外する手順を削除しています。