### PR TITLE
Environment.example.swift に signalingConnectMetadata を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,15 @@
+# 変更履歴
+
+- UPDATE
+    - 下位互換がある変更
+- ADD
+    - 下位互換がある追加
+- CHANGE
+    - 下位互換のない変更
+- FIX
+    - バグ修正
+
+## develop
+
+- [UPDATE] Environment.example.swift に signalingConnectMetadata を追加する 
+    - @miosakuma

--- a/SoraQuickStart/Environment.example.swift
+++ b/SoraQuickStart/Environment.example.swift
@@ -1,11 +1,12 @@
 import Foundation
 
 enum Environment {
-
     // 接続するサーバーのシグナリング URL
     static let url = URL(string: "wss://sora.example.com/signaling")!
 
     // チャネル ID
     static let channelId = "sora"
 
+    // type: connect に含めるメタデータ
+    static let signalingConnectMetadata: Encodable? = nil
 }

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -59,10 +59,13 @@ class ViewController: UIViewController {
 
     func connect() {
         // 接続の設定を行います。
-        let config = Configuration(url: Environment.url,
+        var config = Configuration(url: Environment.url,
                                    channelId: Environment.channelId,
                                    role: .sendrecv,
                                    multistreamEnabled: true)
+
+        // 接続時に指定したいオプションを以下のように設定します。
+        config.signalingConnectMetadata = Environment.signalingConnectMetadata
 
         // ストリームが追加されたら受信用の VideoView をストリームにセットします。
         // このアプリでは、複数のユーザーが接続した場合は最後のユーザーの映像のみ描画します。


### PR DESCRIPTION
Environment.example.swift に signalingConnectMetadata を追加しました。
sora-ios-sdk-samples と構成を合わせるためです。