### PR TITLE
[DO NOT MERGE] H265 検証用ブランチ

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ platform :ios, '13.0'
 
 target 'SoraQuickStart' do
   use_frameworks!
-  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'develop'
+  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'feature/h265'
 #  SwiftLint, SwiftFormat/CLI が Swift 5.8 に対応していないため一時的にコメントアウトする
 #  pod 'SwiftLint'
 #  pod 'SwiftFormat/CLI'

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -63,7 +63,8 @@ class ViewController: UIViewController {
                                    channelId: Environment.channelId,
                                    role: .sendrecv,
                                    multistreamEnabled: true)
-
+        config.videoCodec = VideoCodec.h265
+        
         // 接続時に指定したいオプションを以下のように設定します。
         config.signalingConnectMetadata = Environment.signalingConnectMetadata
 


### PR DESCRIPTION
## メモ

このブランチを動かすには、 WebRTC (= `Pods/WebRTC/WebRTC.xcframework`) を H265 に対応済みのものと置き換える必要があります