### PR TITLE
libwebrtc のログレベルを INFO に設定する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@
 
 ## develop
 
-- [UPDATE] libwebrtc のログレベルを INFO にする
+- [UPDATE] libwebrtc のログレベルを RTCLoggingSeverityNone から RTCLoggingSeverityInfo にする
+  - libwebrtc のログを INFO レベルで出力するようにする
   - @zztkm
 
 ## sora-ios-sdk-2024.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] libwebrtc のログレベルを INFO にする
+  - @zztkm
+
 ## sora-ios-sdk-2024.2.0
 
 - [UPDATE] Github Actions を actions/cache@v4 にあげる

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -20,6 +20,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         Logger.shared.level = .debug
+        Sora.setWebRTCLogLevel(.info)
 
         navigationItem.title = "\(Environment.channelId)"
     }


### PR DESCRIPTION
変更内容

- [UPDATE] libwebrtc のログレベルを RTCLoggingSeverityNone から RTCLoggingSeverityInfo にする
  - libwebrtc のログを INFO レベルで出力するようにする

---

This pull request primarily focuses on updating the logging level of `libwebrtc` from `RTCLoggingSeverityNone` to `RTCLoggingSeverityInfo`. This change affects both the documentation and the codebase.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R17): Updated the development logs to reflect the change in `libwebrtc` logging level. The logs will now output at the INFO level.

Codebase changes:

* [`SoraQuickStart/ViewController.swift`](diffhunk://#diff-06bff0bc560ae4f6560f89cdb2912a9dc54ef97d756f344be4b88f7d8c8bf8d3R23): In the `ViewController` class, the `setWebRTCLogLevel` method of the `Sora` class is now set to `.info` in the `viewDidLoad` function. This change ensures that the logging level of `libwebrtc` is set to INFO when the view is loaded.