### PR TITLE
Github Actions の Xcode を 15.4 にあげる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      XCODE: /Applications/Xcode_15.2.app
-      XCODE_SDK: iphoneos17.2
+      XCODE: /Applications/Xcode_15.4.app
+      XCODE_SDK: iphoneos17.5
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode Version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 - [UPDATE] libwebrtc のログレベルを RTCLoggingSeverityNone から RTCLoggingSeverityInfo にする
   - libwebrtc のログを INFO レベルで出力するようにする
   - @zztkm
+- [UPDATE] GitHub Actions の Xcode のバージョンを 15.4 にあげる
+  - 合わせて iOS の SDK を iphoneos17.5 にあげる
+  - @miosakuma
 
 ## sora-ios-sdk-2024.2.0
 


### PR DESCRIPTION
- [UPDATE] GitHub Actions の Xcode のバージョンを 15.4 にあげる
  - 合わせて iOS の SDK を iphoneos17.5 にあげる
 
---

This pull request includes updates to the GitHub Actions workflow and documentation changes in the `CHANGES.md` file. The most important changes are the upgrade of the Xcode version and the iOS SDK version in the build workflow.

### Updates to GitHub Actions workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L16-R17): Updated the Xcode version to 15.4 and the iOS SDK version to iphoneos17.5.

### Documentation changes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R17-R19): Documented the update of the GitHub Actions Xcode version to 15.4 and the iOS SDK version to iphoneos17.5.