### PR TITLE
iOS 14 にあげる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,14 @@
 
 ## develop
 
+- [UPDATE] CocoaPods の platform の設定を 14.0 に上げる
+  - @miosakuma
+- [UPDATE] システム条件を変更する
+  - iOS 14 以降
+  - macOS 15.0 以降
+  - Xcode 16.0
+  - @miosakuma
+
 ## sora-ios-sdk-2024.3.0
 
 **リリース日**: 2024-09-06

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 source 'https://cdn.cocoapods.org/'
 source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
 
-platform :ios, '13.0'
+platform :ios, '14.0'
 
 target 'SoraQuickStart' do
   use_frameworks!

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Please read https://github.com/shiguredo/oss before use.
 
 ## システム条件
 
-- iOS 13 以降
+- iOS 14 以降
 - アーキテクチャ arm64 (シミュレーターの動作は未保証)
-- macOS 14.6.1 以降
-- Xcode 15.4
+- macOS 15.0 以降
+- Xcode 16.0
 - Swift 5.10
 - CocoaPods 1.15.2 以降
 - WebRTC SFU Sora 2024.1.0 以降


### PR DESCRIPTION
- CocoaPods の platform の設定を 14.0 に上げる
- システム条件を現在の環境に更新する

---

This pull request includes updates to the platform and system requirements for the project. The most important changes are the updates to the minimum iOS version, macOS version, and Xcode version, as well as the corresponding documentation updates.

Platform and system requirements updates:

* [`Podfile`](diffhunk://#diff-8f7d6adf31268a2d897ee34bd170592648d6e520aa237104395e4a4438af50cbL4-R4): Updated the minimum iOS platform version from `13.0` to `14.0`.
* `README.md`: Updated the system requirements to reflect the new minimum versions:
  * iOS 14 or later
  * macOS 15.0 or later
  * Xcode 16.0

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R21): Documented the updates to CocoaPods platform settings and system requirements.