### PR TITLE
GitHub Actions での定期ビルドをやめる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
     - 'README.md'
     - 'CHANGES.md'
     - 'LICENSE'
-  schedule:
-  - cron: "0 0 * * *"
 
 jobs:
   build:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@
   - @zztkm
 - [UPDATE] GitHub Actions での format check をやめる
   - @zztkm
+- [UPDATE] GitHub Actions の定期ビルドをやめる
+  - @zztkm
 
 ## sora-ios-sdk-2025.1.1
 


### PR DESCRIPTION
- [UPDATE] GitHub Actions の定期ビルドをやめる

---

This pull request includes changes to the GitHub Actions workflow and updates to the `CHANGES.md` file. The most important changes are:

GitHub Actions workflow updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L9-L10): Removed the scheduled cron job for the build process.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R35-R36): Added an update entry indicating the removal of the scheduled build in GitHub Actions.