### PR TITLE
フォーマッター実行用の Makefile を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,7 +38,7 @@
   - @zztkm
 - [UPDATE] GitHub Actions の定期ビルドをやめる
   - @zztkm
-- [ADD] swift-format と SwiftLint 実行用の Makefile を追加する
+- [ADD] swift-format 実行用の Makefile を追加する
   - format.sh で一括実行していたコマンドを個別に実行できるようにした
   - @zztkm
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@
   - @zztkm
 - [UPDATE] GitHub Actions の定期ビルドをやめる
   - @zztkm
+- [ADD] swift-format と SwiftLint 実行用の Makefile を追加する
+  - format.sh で一括実行していたコマンドを個別に実行できるようにした
+  - @zztkm
 
 ## sora-ios-sdk-2025.1.1
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt fmt-lint
+
+# swift-format
+fmt:
+	swift format --in-place --recursive SoraQuickStart
+
+# swift-format lint
+fmt-lint:
+	swift format lint --strict --parallel --recursive SoraQuickStart
+
+# すべてを実行
+all: fmt-lint fmt


### PR DESCRIPTION
- [ADD] swift-format と SwiftLint 実行用の Makefile を追加する
  - format.sh で一括実行していたコマンドを個別に実行できるようにした

---

This pull request introduces a new Makefile to run `swift-format` and `SwiftLint` commands separately, enhancing the ability to format and lint Swift code. Additionally, it updates the `CHANGES.md` file to document the new Makefile addition.

### Key changes:

* **Documentation Update:**
  - [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R41-R43): Added an entry to document the addition of the Makefile for `swift-format` and `SwiftLint` execution.

* **Makefile Addition:**
  - [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R12): Introduced new targets `fmt` and `fmt-lint` for running `swift-format` commands, and an `all` target to run both commands.