### PR TITLE
CI に Format Lint を追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE= \
             ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
+    - name: Format Lint
+      run: make fmt-lint
   release:
     if: contains(github.ref, 'tags/v')
     needs: [build]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,8 +34,6 @@
   - Xcode の version を 16.2 に変更
   - SDK を iOS 18.2 に変更
   - @zztkm
-- [UPDATE] GitHub Actions での format check をやめる
-  - @zztkm
 - [UPDATE] GitHub Actions の定期ビルドをやめる
   - @zztkm
 - [ADD] swift-format 実行用の Makefile を追加する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@
   - @zztkm
 - [UPDATE] GitHub Actions の定期ビルドをやめる
   - @zztkm
+- [UPDATE] GitHub Actions での Format Lint で Makefile を利用するように変更
+  - format.sh は利用しなくなったので削除
+  - @zztkm
 - [ADD] swift-format 実行用の Makefile を追加する
   - format.sh で一括実行していたコマンドを個別に実行できるようにした
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
   - フォーマット設定はデフォルトを採用したため、.swift-format は利用しない
   - @zztkm
 - [UPDATE] リンターの実行をシェルスクリプトではなく、Xcode の Build Phases に設定する
+  - lint-format.sh から lint の機能を削除したので、format.sh に改名
   - @zztkm
 - [UPDATE] 依存管理を CocoaPods から Xcode の Swift Package Manager に移行する
   - Sora iOS SDK と SwiftLint を Swift Package Manager 管理に移行
@@ -37,7 +38,7 @@
 - [UPDATE] GitHub Actions の定期ビルドをやめる
   - @zztkm
 - [UPDATE] GitHub Actions での Format Lint で Makefile を利用するように変更
-  - format.sh は利用しなくなったので削除
+  - CI でも Makefile を利用するようになったために format.sh は利用しなくなったので削除
   - @zztkm
 - [ADD] swift-format 実行用の Makefile を追加する
   - format.sh で一括実行していたコマンドを個別に実行できるようにした

--- a/format.sh
+++ b/format.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# formatter を実行するスクリプト
-# フォーマットリントは未フォーマットでもステータスコード 0 を返すので
-# ステータスコードチェックを行わない
-swift format lint -r SoraQuickStart
-swift format -i -r SoraQuickStart
-
-exit $?


### PR DESCRIPTION
format check を一時的にやめていましたが、iOS SDK に合わせて format lint として復活させました。

復活させるさい、format.sh -> Makefile への移行も行いました。

- [UPDATE] GitHub Actions での Format Lint で Makefile を利用するように変更
  - format.sh は利用しなくなったので削除

---


This pull request includes several changes to the build process and formatting tools used in the repository. The most important changes involve updating the GitHub Actions workflow, modifying the `CHANGES.md` file, and removing the `format.sh` script.

Updates to GitHub Actions workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R41-R42): Added a new job to run `make fmt-lint` for formatting and linting.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L37-R41): Updated to reflect the new usage of `Makefile` for format linting and the removal of `format.sh`.

Removal of obsolete script:

* [`format.sh`](diffhunk://#diff-ef87df35455e8abccb373a278caa1c24262425cff2cb2da5fff1d34775702ec2L1-L9): Deleted the script as it is no longer needed with the new `Makefile` usage for format linting.