### PR TITLE
エラーの種類に応じてアラートのタイトルとメッセージを設定する処理を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] エラーの種類に応じてアラートのタイトルとメッセージを設定する処理を追加する
+  - @zztkm
+
 ### misc
 
 - [CHANGE] フォーマッターを SwiftFormat から swift-format に変更する

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -87,10 +87,11 @@ class ViewController: UIViewController {
       }
       if let error {
         NSLog(error.localizedDescription)
+          let errorMessage = self?.handleErrorMessage(error)
         DispatchQueue.main.async {
           let alertController = UIAlertController(
-            title: "接続に失敗しました",
-            message: error.localizedDescription,
+            title: errorMessage?.title,
+            message: errorMessage?.message,
             preferredStyle: .alert)
           alertController.addAction(
             UIAlertAction(title: "OK", style: .cancel, handler: nil))
@@ -128,5 +129,26 @@ class ViewController: UIViewController {
         stream.videoRenderer = self.senderVideoView
       }
     }
+  }
+
+  private func handleErrorMessage(_ error: Error) -> (
+    title: String, message: String
+  ) {
+    var title: String
+    var message: String
+    if let soraError = error as? SoraError {
+      switch soraError {
+      case .webSocketClosed(let code, let reason):
+        title = "Sora から切断されました"
+          message = "ステータスコード: \(code.intValue()), 理由: \(reason ?? "不明")"
+      default:
+        title = "接続に失敗しました"
+        message = error.localizedDescription
+      }
+    } else {
+      title = "接続に失敗しました"
+      message = error.localizedDescription
+    }
+    return (title, message)
   }
 }

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -87,7 +87,7 @@ class ViewController: UIViewController {
       }
       if let error {
         NSLog(error.localizedDescription)
-          let errorMessage = self?.handleErrorMessage(error)
+        let errorMessage = self?.handleErrorMessage(error)
         DispatchQueue.main.async {
           let alertController = UIAlertController(
             title: errorMessage?.title,
@@ -140,7 +140,7 @@ class ViewController: UIViewController {
       switch soraError {
       case .webSocketClosed(let code, let reason):
         title = "Sora から切断されました"
-          message = "ステータスコード: \(code.intValue()), 理由: \(reason ?? "不明")"
+        message = "ステータスコード: \(code.intValue()), 理由: \(reason ?? "不明")"
       default:
         title = "接続に失敗しました"
         message = error.localizedDescription


### PR DESCRIPTION
- [UPDATE] エラーの種類に応じてアラートのタイトルとメッセージを設定する処理を追加する

---

This pull request includes updates to handle error messages more effectively in the `ViewController` class and an update to the `CHANGES.md` file. The most important changes include adding a method to customize alert titles and messages based on error types and updating the alert presentation logic.

Error handling improvements:

* [`SoraQuickStart/ViewController.swift`](diffhunk://#diff-06bff0bc560ae4f6560f89cdb2912a9dc54ef97d756f344be4b88f7d8c8bf8d3R133-R153): Added the `handleErrorMessage` method to customize alert titles and messages based on the type of error encountered.
* [`SoraQuickStart/ViewController.swift`](diffhunk://#diff-06bff0bc560ae4f6560f89cdb2912a9dc54ef97d756f344be4b88f7d8c8bf8d3R90-R94): Updated the alert presentation logic to use the custom titles and messages generated by the `handleErrorMessage` method.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Added an entry describing the new error handling feature.