### PR TITLE
onDisconnect を SoraCloseEvent を用いた処理に更新

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,12 @@
 - FIX
   - バグ修正
 
-## develop
+## 2025.2
 
 - [UPDATE] エラーの種類に応じてアラートのタイトルとメッセージを設定する処理を追加する
+  - @zztkm
+- [UPDATE] `MediaChannelHandlers` の `onDisconnect: ((Error?) -> Void)?` から `onDisconnect: ((SoraCloseEvent) -> Void)?` に移行する
+  - この移行により、Sora との接続が終了した時の理由やステータスコードを取得することが可能になる
   - @zztkm
 
 ### misc


### PR DESCRIPTION
Sora iOS SDK の `onDisconnect: ((Error?) -> Void)?` が `onDisconnect: ((SoraCloseEvent) -> Void)?` に変更になったため、クイックスタートアプリも合わせて対応します。

- [UPDATE] `MediaChannelHandlers` の `onDisconnect: ((Error?) -> Void)?` から `onDisconnect: ((SoraCloseEvent) -> Void)?` に移行する
  - この移行により、Sora との接続が終了した時の理由やステータスコードを取得することが可能になる

---

This pull request refactors the error handling logic in the `ViewController` class of the `SoraQuickStart` project. The changes simplify the code by removing the `handleErrorMessage` method and replacing it with a streamlined approach using a `switch` statement to handle disconnection events directly.

### Error handling improvements:

* Updated the `onDisconnect` handler in `config.mediaChannelHandlers` to use a `switch` statement for handling disconnection events (`.ok` and `.error`) instead of relying on a separate helper method. This change improves readability and centralizes the logic for handling disconnection events. (`[SoraQuickStart/ViewController.swiftL84-R104](diffhunk://#diff-06bff0bc560ae4f6560f89cdb2912a9dc54ef97d756f344be4b88f7d8c8bf8d3L84-R104)`)
* Removed the `handleErrorMessage` method, as its functionality is now integrated directly into the `onDisconnect` handler. This reduces redundancy and simplifies the codebase. (`[SoraQuickStart/ViewController.swiftL133-L153](diffhunk://#diff-06bff0bc560ae4f6560f89cdb2912a9dc54ef97d756f344be4b88f7d8c8bf8d3L133-L153)`)