### PR TITLE
Sora iOS SDK を 2025.2.0-canary.2 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## 2025.2
 
+- [UPDATE] Sora iOS SDK を 2025.2.0 にあげる
+  - @zztkm
 - [UPDATE] エラーの種類に応じてアラートのタイトルとメッセージを設定する処理を追加する
   - @zztkm
 - [UPDATE] `MediaChannelHandlers` の `onDisconnect: ((Error?) -> Void)?` から `onDisconnect: ((SoraCloseEvent) -> Void)?` に移行する

--- a/SoraQuickStart.xcodeproj/project.pbxproj
+++ b/SoraQuickStart.xcodeproj/project.pbxproj
@@ -372,7 +372,7 @@
 			repositoryURL = "https://github.com/shiguredo/sora-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2025.1.1;
+				minimumVersion = "2025.2.0-canary.2";
 			};
 		};
 		B36C6DFD2D55D9B800DC4F4D /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -89,16 +89,16 @@ class ViewController: UIViewController {
       case .ok(let code, let reason):
         NSLog("接続解除: ステータスコード: \(code), 理由: \(reason)")
       case .error(let error):
-          NSLog(error.localizedDescription)
-          DispatchQueue.main.async {
-            let alertController = UIAlertController(
-              title: "接続エラーが発生しました",
-              message: error.localizedDescription,
-              preferredStyle: .alert)
-            alertController.addAction(
-              UIAlertAction(title: "OK", style: .cancel, handler: nil))
-            self?.present(alertController, animated: true, completion: nil)
-          }
+        NSLog(error.localizedDescription)
+        DispatchQueue.main.async {
+          let alertController = UIAlertController(
+            title: "接続エラーが発生しました",
+            message: error.localizedDescription,
+            preferredStyle: .alert)
+          alertController.addAction(
+            UIAlertAction(title: "OK", style: .cancel, handler: nil))
+          self?.present(alertController, animated: true, completion: nil)
+        }
         strongSelf.updateUI(false)
       }
     }


### PR DESCRIPTION
※ 実際には canary バージョンだが 2025.2.0 と表記しておく

- [UPDATE] Sora iOS SDK を 2025.2.0 にあげる