### PR TITLE
Github Actions ビルドの iOS バージョン更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     env:
-      XCODE: /Applications/Xcode_16.3.app
-      XCODE_SDK: iphoneos18.4
+      XCODE: /Applications/Xcode_26.2.app
+      XCODE_SDK: iphoneos26.2
     steps:
     - uses: actions/checkout@v5
     - name: Select Xcode Version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
 
 ### misc
 
+- [UPDATE] Github Actions のビルド環境を更新する
+  - Xcode の version を 26.2 に変更
+  - SDK を iOS 26.2 に変更
 - [UPDATE] actions/checkout を v5 に上げる
   - @miosakuma
 


### PR DESCRIPTION
26.2 に更新