### PR TITLE
[WIP] Swift 6 言語モードでビルドできるようにする

### DIFF
--- a/SoraQuickStart.xcodeproj/project.pbxproj
+++ b/SoraQuickStart.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shiguredo.sora.SoraQuickStart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -338,7 +338,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = jp.shiguredo.sora.SoraQuickStart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/SoraQuickStart/Environment.example.swift
+++ b/SoraQuickStart/Environment.example.swift
@@ -8,5 +8,5 @@ enum Environment {
   static let channelId = "sora"
 
   // type: connect に含めるメタデータ
-  static let signalingConnectMetadata: Encodable? = nil
+  static let signalingConnectMetadata: (any Encodable & Sendable)? = nil
 }

--- a/SoraQuickStart/ViewController.swift
+++ b/SoraQuickStart/ViewController.swift
@@ -1,4 +1,4 @@
-import Sora
+@preconcurrency import Sora
 import UIKit
 import os
 


### PR DESCRIPTION
## 概要
- SoraQuickStart ターゲットの `SWIFT_VERSION` を 6.0 に変更
- `Environment.example.swift` の `signalingConnectMetadata` を `(any Encodable & Sendable)?` に変更
- `ViewController.swift` の `Sora` import を `@preconcurrency import Sora` に変更

